### PR TITLE
Add spec for the membership form

### DIFF
--- a/admin/pages/Landing_Page.md
+++ b/admin/pages/Landing_Page.md
@@ -1,43 +1,44 @@
 # Landing Page
 
-This page will have a cool graphic that captures the charm of relay. It will have the following information on it: 
+This page will have a cool graphic that captures the charm of relay. It will have the following information on it:
 
 ## Page Features
+
 - hero with nav, full page pic, call to action
 - photo gallery slider
 - historical blurb
 - unique community attributes
 - map
+
 # Homepage
 
 At the top have some badges to connect to social accounts for the community
 
-## Community News and Calendar 
+## Community News and Calendar
 
 News and Calendar side by side fed from Google
 
-*Newsletter*: https://drive.google.com/drive/folders/1tnylUSYgV8uzQ-xCmbAT1JVFGPSed1bn?usp=drive_link
+_Newsletter_: https://drive.google.com/drive/folders/1tnylUSYgV8uzQ-xCmbAT1JVFGPSed1bn?usp=drive_link
 
-*Calendar*: <iframe src="https://calendar.google.com/calendar/embed?src=relayimprovementassociation%40gmail.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+_Calendar_: <iframe src="https://calendar.google.com/calendar/embed?src=relayimprovementassociation%40gmail.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 
-## Community History - Snippet 
+## Community History - Snippet
 
-The village of Relay is halfway between Baltimore and Ellicott City. It was created in 1830 as a change point, or “relay,” for horses hauling the first scheduled railroad cars in the United States.
+The village of Relay is halfway between Baltimore and Ellicott City. It was created in 1830 as a change point, or "relay," for horses hauling the first scheduled railroad cars in the United States.
 
 ## Unique Community attributes
 
-Historic Relay and St. Denis is a vibrant destination. Nearby is the glorious Patapsco State Park and National historic landmark Thomas Viaduct. Relay is a popular destination for train, recreation and exercise enthusiasts. The picturesque streets highlight the glory of historic Baltimore County Maryland. 
+Historic Relay and St. Denis is a vibrant destination. Nearby is the glorious Patapsco State Park and National historic landmark Thomas Viaduct. Relay is a popular destination for train, recreation and exercise enthusiasts. The picturesque streets highlight the glory of historic Baltimore County Maryland.
 
-* Well-preserved residential architecture
+- Well-preserved residential architecture
 
-* Tradition of activism and community engagement
+- Tradition of activism and community engagement
 
-* Within Walking distance to Public Library and Senior Center
+- Within Walking distance to Public Library and Senior Center
 
-* Close to BWI
+- Close to BWI
 
-* MARC train to go to Washington DC.
-
+- MARC train to go to Washington DC.
 
 ## Community Location
 
@@ -49,6 +50,6 @@ A small blurb about RIA link to page about the association?
 
 call to action to become a memeber of the RIA and donate.
 
-## Footer for the page 
+## Footer for the page
 
 links to social media, maybe newsletter signup with reCAPTCHA

--- a/admin/pages/Neighborhood_Info.md
+++ b/admin/pages/Neighborhood_Info.md
@@ -1,21 +1,20 @@
-## Community History - Snippet 
+## Community History - Snippet
 
-The village of Relay is halfway between Baltimore and Ellicott City. It was created in 1830 as a change point, or “relay,” for horses hauling the first scheduled railroad cars in the United States.
+The village of Relay is halfway between Baltimore and Ellicott City. It was created in 1830 as a change point, or "relay," for horses hauling the first scheduled railroad cars in the United States.
 
 ## Unique Community attributes
 
-Historic Relay and St. Denis is a vibrant destination. Nearby is the glorious Patapsco State Park and National historic landmark Thomas Viaduct. Relay is a popular destination for train, recreation and exercise enthusiasts. The picturesque streets highlight the glory of historic Baltimore County Maryland. 
+Historic Relay and St. Denis is a vibrant destination. Nearby is the glorious Patapsco State Park and National historic landmark Thomas Viaduct. Relay is a popular destination for train, recreation and exercise enthusiasts. The picturesque streets highlight the glory of historic Baltimore County Maryland.
 
-* Well-preserved residential architecture
+- Well-preserved residential architecture
 
-* Tradition of activism and community engagement
+- Tradition of activism and community engagement
 
-* Within Walking distance to Public Library and Senior Center
+- Within Walking distance to Public Library and Senior Center
 
-* Close to BWI
+- Close to BWI
 
-* MARC train to go to Washington DC.
-
+- MARC train to go to Washington DC.
 
 ## Community Location
 

--- a/cypress/e2e/ria.cy.ts
+++ b/cypress/e2e/ria.cy.ts
@@ -1,3 +1,5 @@
+const GOOGLE_DRIVE_FILE_RE = /^https:\/\/drive\.google\.com\/file\/d\/[^/]+\//;
+
 describe("RIA membership page", () => {
   beforeEach(() => {
     cy.visit("/ria");
@@ -43,6 +45,44 @@ describe("RIA membership page", () => {
       .should("be.visible")
       .and("have.attr", "target", "_blank")
       .and("have.attr", "rel", "noopener noreferrer");
+  });
+
+  it("shows the downloadable membership form and opens a valid Google Drive document", () => {
+    cy.contains("h3", "Membership form").should("be.visible");
+
+    cy.contains("a", "RIA membership form")
+      .should("be.visible")
+      .should(($a) => {
+        expect($a.attr("href"), "membership form href").to.match(
+          GOOGLE_DRIVE_FILE_RE,
+        );
+      })
+      // Alias so we can refer to this same link again without repeating cy.contains (use @name with cy.get).
+      .as("membershipForm");
+
+    // cy.get("@alias") re-queries the element saved by .as("alias") above.
+    cy.get("@membershipForm")
+      .invoke("attr", "href")
+      .then((href) => {
+        expect(href, "membership form href").to.be.a("string").and.not.be.empty;
+        cy.request(href as string).then((response) => {
+          expect(response.status, "membership form URL responds").to.eq(200);
+          expect(
+            response.body.length,
+            "membership form URL returns a non-empty document",
+          ).to.be.greaterThan(500);
+        });
+      });
+
+    cy.get("@membershipForm").click(); // same aliased link
+
+    // After the click, the browser is on drive.google.com (different origin than localhost). Commands
+    // that run on that page must live inside cy.origin with that site’s origin.
+    cy.origin("https://drive.google.com", () => {
+      cy.url().should("match", /drive\.google\.com\/file\/d\/[^/?]+/);
+      cy.get("body").should("be.visible");
+      cy.title().should("not.be.empty");
+    });
   });
 
   it("embeds the current newsletter PDF under the Newsletter heading", () => {

--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -9,7 +9,7 @@ const EXPECTED_TITLES: Record<string, string> = {
 
 describe("Page titles", () => {
   for (const [path, title] of Object.entries(EXPECTED_TITLES)) {
-    it(`sets the document title to “${title}” on ${path}`, () => {
+    it(`sets the document title to "${title}" on ${path}`, () => {
       cy.visit(path);
       cy.title().should("eq", title);
     });

--- a/src/pages/resources.md
+++ b/src/pages/resources.md
@@ -7,32 +7,33 @@ title: Community Resources
 
 ### The Relay Historic District and the Landmarks Preservation Commission
 
-In the 1990’s home-owners in the Relay neighborhood banded together and petitioned that the core of the neighborhood be designated a County Historic District.  This was done to preserve the unique architectural nature of the neighborhood, many of whose post-Civil War houses were built in the Victorian or Craftsman style.
-The boundaries of the Relay Historic District can be seen in this map.  If you own a property within these boundaries, you are subject to the historic preservation regulations of Baltimore County.
+In the 1990’s home-owners in the Relay neighborhood banded together and petitioned that the core of the neighborhood be designated a County Historic District. This was done to preserve the unique architectural nature of the neighborhood, many of whose post-Civil War houses were built in the Victorian or Craftsman style.
+The boundaries of the Relay Historic District can be seen in this map. If you own a property within these boundaries, you are subject to the historic preservation regulations of Baltimore County.
 
 ![map_historic_home_guide](../img/map_historic_home_guide.jpg)
 
-The Landmarks Preservation Commission is the County commission charged with enforcing the historic preservation regulations in Baltimore County.   But what does that mean for you, the home-owner? 
+The Landmarks Preservation Commission is the County commission charged with enforcing the historic preservation regulations in Baltimore County. But what does that mean for you, the home-owner?
 
 ### Renovations and Rehabilitations
 
-If you want to renovate or rehabilitate any part of the **EXTERIOR** of your property, you will have to get a special permit from the LPC.   This would apply to changes to your roof, sidings, windows, doors, and trim.   It does NOT apply to repainting.   In general, they want to make sure that you preserve the original appearance of the building, and not make changes that would significantly change that appearance – e.g., replacing an historic slate or metal roof with asphalt shingles.
+If you want to renovate or rehabilitate any part of the **EXTERIOR** of your property, you will have to get a special permit from the LPC. This would apply to changes to your roof, sidings, windows, doors, and trim. It does NOT apply to repainting. In general, they want to make sure that you preserve the original appearance of the building, and not make changes that would significantly change that appearance – e.g., replacing an historic slate or metal roof with asphalt shingles.
 The LPC does NOT control what you do to the interior of your home, but see below for some tax credit benefits of interior renovations.
 The forms and instructions on how to apply for these permits can be found at: [https://www.baltimorecountymd.gov/departments/planning/historic-preservation/historic-review](https://www.baltimorecountymd.gov/departments/planning/historic-preservation/historic-review)
 The good news is that many homes built after about 1930 will not need extensive review, and can often be approved by the LPC staff without review by the whole LPC Commission.
 
 ### Minor Repairs
 
-If you are just repairing some minor issues like replacing some window trim or missing shingles, this does not need LPC review, as long as you “replace like with like”, i.e., replace rotten window trim with the same material in the same style.  If you’re not sure if your work is too large to be considered a repair rather than a renovation, contact the LPC staff to check.  They tend to be very responsive.  They can be contacted at: [histpres@baltimorecountymd.gov](histpres@baltimorecountymd.gov) or by phone at [410-887-3495](410-887-3495).
+If you are just repairing some minor issues like replacing some window trim or missing shingles, this does not need LPC review, as long as you "replace like with like", i.e., replace rotten window trim with the same material in the same style. If you’re not sure if your work is too large to be considered a repair rather than a renovation, contact the LPC staff to check. They tend to be very responsive. They can be contacted at: [histpres@baltimorecountymd.gov](histpres@baltimorecountymd.gov) or by phone at [410-887-3495](410-887-3495).
 
 ### What if I don’t get the LPC permits?
 
-If you don’t get permission for major renovations, you could be hit with code violation “stop work” orders from the County, incurring loss of time and extra costs, and even fines.
+If you don’t get permission for major renovations, you could be hit with code violation "stop work" orders from the County, incurring loss of time and extra costs, and even fines.
 
 ### Historic Tax Credit
-So here’s the good news! If you own a historic home in the Relay Historic District, you may be able to get a tax credit for certain rehabilitation projects through Baltimore County.   This would mean 20% of your renovation costs rebated from your property tax bill.   This covers not only the exterior renovations noted above, but could also be applied for for interior renovations such as upgrades to your plumbing, electric, heating and cooling.   See their [Historic Rehabilitation Tax Credit](https://www.baltimorecountymd.gov/departments/planning/historic_preservation/taxcreditfaq.html) program to learn how to apply for the credit.
 
-The State of Maryland’s Maryland Historic Trust offers its own tax credit program for an additional 20% rebate on your state income taxes, but they have their own application and review process.   See [https://mht.maryland.gov/Pages/funding/tax-credits-homeowner.aspx](https://mht.maryland.gov/Pages/funding/tax-credits-homeowner.aspx)
+So here’s the good news! If you own a historic home in the Relay Historic District, you may be able to get a tax credit for certain rehabilitation projects through Baltimore County. This would mean 20% of your renovation costs rebated from your property tax bill. This covers not only the exterior renovations noted above, but could also be applied for for interior renovations such as upgrades to your plumbing, electric, heating and cooling. See their [Historic Rehabilitation Tax Credit](https://www.baltimorecountymd.gov/departments/planning/historic_preservation/taxcreditfaq.html) program to learn how to apply for the credit.
+
+The State of Maryland’s Maryland Historic Trust offers its own tax credit program for an additional 20% rebate on your state income taxes, but they have their own application and review process. See [https://mht.maryland.gov/Pages/funding/tax-credits-homeowner.aspx](https://mht.maryland.gov/Pages/funding/tax-credits-homeowner.aspx)
 
 ### Preservation Links
 


### PR DESCRIPTION
This PR adds a test for the membership form linked from the RIA page, another critical business rule. It also replaces curly quotes with straight quotes throughout the codebase, thereby running a couple admin pages through the formatter.